### PR TITLE
Fan out into messages to create maps (instead of doing all maps in 1 invocation, do 1 map per invocation)

### DIFF
--- a/fraud-detection-generate-maps/main.py
+++ b/fraud-detection-generate-maps/main.py
@@ -61,8 +61,8 @@ def receive_pubsub_message_generate_maps(cloud_event):
     mapbiomas_land_use_base_map = generate_initial_map(land_use_mapbiomas_image)
 
     if doc.exists:
-        print(f'Document exists, generating map for {document_id}')
         document_id = pub_sub_message
+        print(f'Document exists, generating map for {document_id}')
         doc_dict = doc.to_dict()
         if 'lat' in doc_dict and 'lon' in doc_dict:
             generate_full_map_and_upload_to_gcs(doc_dict['lat'], doc_dict['lon'], land_use_mapbiomas_image, mapbiomas_land_use_base_map, document_id)

--- a/fraud-detection-generate-maps/main.py
+++ b/fraud-detection-generate-maps/main.py
@@ -17,9 +17,9 @@ GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "river-sky-386919")
 # Topic ID for GCS Pub/Sub topic. See fraud-detection-generate-maps/main.py for context.
 TOPIC_ID = "fraud-detection-generate-maps-daily"
 
-# Pub/Sub message to generate all maps. This is set in the Cloud Pub/Sub topic.
+# Pub/Sub message to generate all maps (for every document) This is set in the Cloud Pub/Sub topic.
 # See `fraud-detection-generate-maps-daily` Cloud Pub/Sub topic.
-ALL_DOCS_MESSAGE_CONTENT = "ALL_DOCS"
+ALL_MAPS_MESSAGE_CONTENT = "ALL_MAPS"
 
 # Google Cloud Storage bucket name and folder name
 GCS_BUCKET_NAME = "timberid-public-to-internet"
@@ -68,7 +68,7 @@ def receive_pubsub_message_generate_maps(cloud_event):
             generate_full_map_and_upload_to_gcs(doc_dict['lat'], doc_dict['lon'], land_use_mapbiomas_image, mapbiomas_land_use_base_map, document_id)
         else:
             print(f'Document {document_id} does not contain lat and lon.')
-    elif pub_sub_message == ALL_DOCS_MESSAGE_CONTENT:
+    elif pub_sub_message == ALL_MAPS_MESSAGE_CONTENT:
         print(f'Received message: {pub_sub_message}, generating all maps')
 
         # Get all documents in the collection

--- a/fraud-detection-generate-maps/requirements.txt
+++ b/fraud-detection-generate-maps/requirements.txt
@@ -9,3 +9,4 @@ ee
 geemap
 google-auth
 google-cloud-storage
+google-cloud-pubsub


### PR DESCRIPTION
Instead of creating all maps in a single invocation, create one map per invocation. Also instead of generating all maps on any message that's not a document_id, have a specific constant string to trigger it. This is triggered once a day because the `geemap` JS map resources expire after 48hrs. 

---

# BEFORE THIS CHANGE:

For any message other than a document_id, generate all maps for all documents. This happens in a single invocation. 

However, I noticed this is failing after a few messages. Example of errors before this change is made:
- First few maps succeeds, eventually invocation fails: https://screenshot.googleplex.com/5pTLgdnpJorFyw9
- Example error 1: https://screenshot.googleplex.com/87qQVH9FyfCBU9U
- Example error 2: https://screenshot.googleplex.com/6SZEfHJKcgSLVzb

## Why this is happening:

This error happens when Python makes a requests to some endpoint. I believe this is not related to API quota issues, as it happens with different APIs (sometimes for storage, sometimes and for GEE endpoints).

Instead, I think we're hitting a cloud function per-invocation limit, as suggested by this YAQS https://yaqs.corp.google.com/eng/q/6981166561633501184#a1 (internal google link). Fanning out to one invocation per map/document prevents this.

---

# AFTER THIS CHANGE:

When the function receives message "ALL_MAPS" (the daily trigger to "fraud-detection-generate-maps-daily"), fan out and generate a map per id.

Otherwise, behave as before (when it receives a document id, generate only the map for that document.

Tested:

1. publishes the messages: https://screenshot.googleplex.com/7tW5xpdFcv836gZ
2. Generates all the maps. No errors:
https://screenshot.googleplex.com/Y6TXMDNBBvUYpi9